### PR TITLE
7.1.1

### DIFF
--- a/Source/DnnDocuments/DNN_Documents.dnn
+++ b/Source/DnnDocuments/DNN_Documents.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="DNN_Documents" type="Module" version="07.01.00">
+    <package name="DNN_Documents" type="Module" version="07.01.01">
       <friendlyName>Documents</friendlyName>
       <description>This module renders a list of documents, including links to browse or download the document. 
         Documents includes an edit page, which allows authorized users to edit the information about the Documents 

--- a/Source/DnnDocuments/EditDocs.ascx.vb
+++ b/Source/DnnDocuments/EditDocs.ascx.vb
@@ -615,35 +615,12 @@ Namespace DotNetNuke.Modules.Documents
 
         Private Sub PopulateOwnerList()
             ' populate owner list
-            Dim objUser As List(Of DotNetNuke.Entities.Users.UserInfo)
-            objUser = UserController.GetUsers(False, False, PortalId).Cast(Of UserInfo)().Distinct().ToList()
+            lstOwner.DataSource = UserController.GetUsers(Null.NullInteger).Cast(Of UserInfo).Distinct().OrderBy(Function(i As UserInfo) i.DisplayName)
 
-            'load owners into the owner list
-            lstOwner.DataSource = objUser.OrderBy(Function(i As UserInfo) i.DisplayName)
             lstOwner.DataTextField = "DisplayName"
             lstOwner.DataValueField = "UserId"
 
             lstOwner.DataBind()
-
-            'GetUsers doesn't return super-users, but they can own documents
-            Dim objSuperUser As List(Of DotNetNuke.Entities.Users.UserInfo)
-            objSuperUser = UserController.GetUsers(Null.NullInteger).Cast(Of UserInfo)().Distinct().ToList()
-
-            'Compare the two lists and remove the duplicate super user
-            If objSuperUser.Any() Then
-                For Each user As DotNetNuke.Entities.Users.UserInfo In objUser
-                    For Each superuser As DotNetNuke.Entities.Users.UserInfo In objSuperUser
-                        If user.DisplayName = superuser.DisplayName Then
-                            lstOwner.Items.Remove(superuser.DisplayName)
-                            Exit For
-                        Else
-                            lstOwner.Items.Insert(0, New System.Web.UI.WebControls.ListItem(superuser.DisplayName, superuser.UserID.ToString))
-                            Exit For
-                        End If
-                    Next
-                Next
-            End If
-
 
             lstOwner.Items.Insert(0, New System.Web.UI.WebControls.ListItem(Services.Localization.Localization.GetString("None_Specified"), "-1"))
             '' End With

--- a/Source/DnnDocuments/EditDocs.ascx.vb
+++ b/Source/DnnDocuments/EditDocs.ascx.vb
@@ -272,9 +272,11 @@ Namespace DotNetNuke.Modules.Documents
             Dim fileRolesList As List(Of PermissionInfoBase) = FileRoles.ToList()
             Dim fileReadRoles As IEnumerable(Of PermissionInfoBase) = From fileRole In fileRolesList Where fileRole.PermissionKey = "READ"
             For Each fileRole As FolderPermissionInfo In fileReadRoles
-                objFileRoles.Add(fileRole.RoleName, fileRole.RoleName)
-                If fileRole.RoleName = DotNetNuke.Common.Globals.glbRoleAllUsersName Then
-                    Return True
+                If Not fileRole.RoleName = "" Then
+                    objFileRoles.Add(fileRole.RoleName, fileRole.RoleName)
+                    If fileRole.RoleName = DotNetNuke.Common.Globals.glbRoleAllUsersName Then
+                        Return True
+                    End If
                 End If
             Next
 


### PR DESCRIPTION
**Changes Included**
Implemented a Rolename check to not add a role if the role name is null or empty.

**Testing Steps**
Create a new folder thru FileManager in DNN 9 instance
Install DNN Documents module.
Add a new file and place it in the new folder
You should not be receiving the following error when updating:

`Error: is currently unavailable. DotNetNuke.Services.Exceptions.ModuleLoadException: Item has already been added. Key in dictionary: '' Key being added: '' ---> System.ArgumentException: Item has already been added. Key in dictionary: '' Key being added: '' at System.Collections.Hashtable.Insert(Object key, Object nvalue, Boolean add) at DotNetNuke.Modules.Documents.EditDocs.CheckRolesMatch(ModulePermissionCollection ModuleRoles, FolderPermissionCollection FileRoles) at DotNetNuke.Modules.Documents.EditDocs.CheckFileSecurity(String Url) at DotNetNuke.Modules.Documents.EditDocs.Update(Boolean Override) --- End of inner exception stack trace ---`
